### PR TITLE
Remove the need for FUSE by extracting the AppImage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ RUN mkdir -p "${CONFIG_DIR}" && touch "${CONFIG_DIR}/eulaAccepted"
 # Configure
 RUN mkdir -p "${UNITY_DIR}/editors"
 
-# Accept license
-COPY bootstrapper.sh .
-COPY no-really-lets-click-everywhere.sh .
+# Note that because Docker kills processes too fast, `RUN xvfb-run` leaves
+# a /tmp/.X99-lock file around which hampers further executions of `xvfb-run`.
+# See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=932070
+# Hence the "sleep 1" addition.
+RUN xvfb-run --auto-servernum --error-file=/dev/stdout "$UNITY_HUB_BIN" --no-sandbox --headless install-path --set "${UNITY_DIR}/editors/" \
+    && sleep 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,17 +20,19 @@ RUN apt-get -q update \
     curl \
     && apt-get clean
 
-# Download
 ENV UNITY_DIR="/opt/unity"
-ENV UNITY_BIN="${UNITY_DIR}/UnityHub.AppImage"
-RUN mkdir "${UNITY_DIR}" \
-    && wget --no-verbose -O "${UNITY_BIN}" "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage" \
-    && chmod +x "${UNITY_BIN}"
 
-# Extract
-RUN cd /tmp \
-    && "${UNITY_BIN}" --appimage-extract \
-    && ls -alh squashfs-root
+# Download & extract AppImage
+RUN wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage" \
+    && chmod +x /tmp/UnityHub.AppImage \
+    && cd /tmp \
+    && /tmp/UnityHub.AppImage --appimage-extract \
+    && cp -R /tmp/squashfs-root/* / \
+    && rm -rf /tmp/squashfs-root /tmp/UnityHub.AppImage \
+    && mkdir -p "$UNITY_DIR" \
+    && mv /AppRun /opt/unity/UnityHub
+
+ENV UNITY_HUB_BIN="/opt/unity/UnityHub"
 
 # Accept
 ENV CONFIG_DIR="/root/.config/Unity Hub"

--- a/README.md
+++ b/README.md
@@ -29,26 +29,12 @@ Just to run the image
 docker run -it --rm proto bash
 ```
 
-> _The flags `--cap-add SYS_ADMIN` and `--device /dev/fuse` are needed for Fuse to work._
-
-```bash
-docker run -it --rm --cap-add SYS_ADMIN --device /dev/fuse proto bash
-```
-
-> _Docker security profile `--security-opt apparmor:unconfined`._
-
-```bash
-docker run -it --rm --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined proto bash
-```
-
-> _Currently it is unsure whether the security profile is needed or not._
-
 ## Configure
 
 Configure editor path
 
 ```
-xvfb-run -e /dev/stdout /opt/unity/UnityHub.AppImage --no-sandbox --headless install-path --set /opt/unity/editors/
+xvfb-run -e /dev/stdout /opt/unity/UnityHub --no-sandbox --headless install-path --set /opt/unity/editors/
 ```
 
 ## Run UnityHub
@@ -60,7 +46,7 @@ xvfb-run -e /dev/stdout /opt/unity/UnityHub.AppImage --no-sandbox --headless ins
 Run the help command
 
 ```bash
-xvfb-run -e /dev/stdout /opt/unity/UnityHub.AppImage --no-sandbox --headless help
+xvfb-run -e /dev/stdout /opt/unity/UnityHub --no-sandbox --headless help
 ```
 
 #### install
@@ -72,7 +58,7 @@ The link `unityhub://2020.1.4f1/fa717bb873ec` holds version `2020.1.4f1` and has
 Since we want to install android build support, we'll add `--module android`.
 
 ```bash
-xvfb-run -e /dev/stdout /opt/unity/UnityHub.AppImage --no-sandbox --headless install --version 2020.1.4f1 --changeset fa717bb873ec --module android
+xvfb-run -e /dev/stdout /opt/unity/UnityHub --no-sandbox --headless install --version 2020.1.4f1 --changeset fa717bb873ec --module android
 ```
 
 ## Todo

--- a/bootstrapper.sh
+++ b/bootstrapper.sh
@@ -6,4 +6,4 @@ echo "starting clicker"
 
 # start unity hub
 echo "starting unity hub"
-xvfb-run -e /dev/stdout /opt/unity/UnityHub.AppImage
+xvfb-run -e /dev/stdout /opt/unity/UnityHub


### PR DESCRIPTION
For the AppImage contents to work correctly, the files contained in the AppImage must be accessible at their absolute paths (that's what the AppImage runtime does, overlaying the FUSE-mounted filesystem over the root FS).

Since we're building a Unity-specific docker image, there is no harm in "permanently" copying those files at the root of the image's filesystem. This then makes the AppImage's entrypoint `AppRun` work.

This PR also contains an example of running Unity Hub from the `Dockerfile`. Note the small wrinkle of having to wait for `Xvfb` to clean up its lockfile.