### PR TITLE
Required dependencies added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN apt-get -q update \
     libdbus-glib-1-2 \
     xdotool \
     curl \
+    xz-utils \
+    cpio \
+    lsb-release \
     && apt-get clean
 
 ENV UNITY_DIR="/opt/unity"


### PR DESCRIPTION
### Fixes
- editor installation issues (xz-utils missing while extracting)
- android build support installation issue (cpio missing)

### Notes
- Unity hub expects `APPIMAGE` env var same value as `UNITY_HUB_BIN`, to be set to the path of the hub executable used in systeminfo.js for logging couldn't find any other use of it
- lsb-release is required at run time (while building projects) to avoid warnings from Roslyn compiler (thanks to ZeppelinAlex)
- I would recommend installing editor and modules as 2 separate commands using `install-module` command
  - editor installation step can be cached by docker if error occurs while installing modules (which can happen)
  - install-module flag doesn't log progress so you can use --debug-mode to see download progress
  - using the `--cm` flag child modules (i.e sdk, ndk, jdk) are installed automatically
```
# Set unity install location
RUN xvfb-run --auto-servernum -e /dev/stdout "$UNITY_HUB_BIN" --no-sandbox --headless install-path --set "${UNITY_DIR}/editors/" \
    && sleep 1

# Install unity editor
RUN xvfb-run --auto-servernum -e /dev/stdout "$UNITY_HUB_BIN" --no-sandbox --headless install --version 2020.1.7f1 \
    && sleep 1

# Install android module with child modules
RUN xvfb-run --auto-servernum -e /dev/stdout "$UNITY_HUB_BIN" --no-sandbox --debug-mode --headless install-modules \
    --version 2020.1.7f1 -m android --cm && sleep 1

# Log installed unity editors
RUN xvfb-run --auto-servernum -e /dev/stdout "$UNITY_HUB_BIN" --no-sandbox --headless editors -i && sleep 1
```