### PR TITLE
Tmpfs mount to circumvent xvfb lock file issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:experimental
 FROM ubuntu:20.04
 
 RUN apt-get -q update \
@@ -8,7 +9,6 @@ RUN apt-get -q update \
     libxtst6 \
     libxss1 \
     desktop-file-utils \
-    fuse \
     libasound2 \
     libgtk2.0-0 \
     libnss3 \
@@ -22,14 +22,12 @@ RUN apt-get -q update \
     lsb-release \
     && apt-get clean
 
-# Inject patched binaries
-COPY xvfb-run /usr/bin/
-
 # Environment
 ENV UNITY_DIR="/opt/unity"
 
 # Download & extract AppImage
-RUN wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage" \
+RUN --mount=type=tmpfs,target=/tmp \
+    wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage" \
     && chmod +x /tmp/UnityHub.AppImage \
     && cd /tmp \
     && /tmp/UnityHub.AppImage --appimage-extract \
@@ -39,13 +37,18 @@ RUN wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3
     && mv /AppRun /opt/unity/UnityHub
 
 # Alias to "unity-hub" or simply "hub" with default params
-RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout /opt/unity/UnityHub --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
+RUN echo '#!/bin/bash\nxvfb-run -e /dev/stdout /opt/unity/UnityHub --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
     && chmod +x /usr/bin/unity-hub \
     && ln -s /usr/bin/unity-hub /usr/bin/hub
 
-RUN echo test
 # Accept
 RUN mkdir -p "/root/.config/Unity Hub" && touch "/root/.config/Unity Hub/eulaAccepted"
 
 # Configure
-RUN mkdir -p "${UNITY_DIR}/editors" && unity-hub install-path --set "${UNITY_DIR}/editors/"
+RUN --mount=type=tmpfs,target=/tmp \
+    mkdir -p "${UNITY_DIR}/editors" \
+    && unity-hub install-path --set "${UNITY_DIR}/editors/"
+
+RUN unity-hub install --version 2020.1.7f1
+
+RUN unity-hub editors -i

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,3 @@ RUN mkdir -p "/root/.config/Unity Hub" && touch "/root/.config/Unity Hub/eulaAcc
 RUN --mount=type=tmpfs,target=/tmp \
     mkdir -p "${UNITY_DIR}/editors" \
     && unity-hub install-path --set "${UNITY_DIR}/editors/"
-
-RUN unity-hub install --version 2020.1.7f1
-
-RUN unity-hub editors -i


### PR DESCRIPTION
### Fixes
- no need for -a or sleep 1 for xvfb to clean up lock file

### Notes
- docker build kit must be enabled to build this image
- unity hub invocation in docker file must be preceded with `--mount=type=tmpfs,target=/tmp`