### PR TITLE
Revert "Tmpfs mount to circumvent xvfb lock file issues"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,6 @@ RUN apt-get -q update \
     lsb-release \
     && apt-get clean
 
-# Inject patched binaries
-COPY xvfb-run /usr/bin/
-
 # Environment
 ENV UNITY_DIR="/opt/unity"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:experimental
 FROM ubuntu:20.04
 
 RUN apt-get -q update \
@@ -9,6 +8,7 @@ RUN apt-get -q update \
     libxtst6 \
     libxss1 \
     desktop-file-utils \
+    fuse \
     libasound2 \
     libgtk2.0-0 \
     libnss3 \
@@ -22,12 +22,14 @@ RUN apt-get -q update \
     lsb-release \
     && apt-get clean
 
+# Inject patched binaries
+COPY xvfb-run /usr/bin/
+
 # Environment
 ENV UNITY_DIR="/opt/unity"
 
 # Download & extract AppImage
-RUN --mount=type=tmpfs,target=/tmp \
-    wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage" \
+RUN wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage" \
     && chmod +x /tmp/UnityHub.AppImage \
     && cd /tmp \
     && /tmp/UnityHub.AppImage --appimage-extract \
@@ -37,14 +39,13 @@ RUN --mount=type=tmpfs,target=/tmp \
     && mv /AppRun /opt/unity/UnityHub
 
 # Alias to "unity-hub" or simply "hub" with default params
-RUN echo '#!/bin/bash\nxvfb-run -e /dev/stdout /opt/unity/UnityHub --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
+RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout /opt/unity/UnityHub --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
     && chmod +x /usr/bin/unity-hub \
     && ln -s /usr/bin/unity-hub /usr/bin/hub
 
+RUN echo test
 # Accept
 RUN mkdir -p "/root/.config/Unity Hub" && touch "/root/.config/Unity Hub/eulaAccepted"
 
 # Configure
-RUN --mount=type=tmpfs,target=/tmp \
-    mkdir -p "${UNITY_DIR}/editors" \
-    && unity-hub install-path --set "${UNITY_DIR}/editors/"
+RUN mkdir -p "${UNITY_DIR}/editors" && unity-hub install-path --set "${UNITY_DIR}/editors/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get -q update \
     libxtst6 \
     libxss1 \
     desktop-file-utils \
-    fuse \
     libasound2 \
     libgtk2.0-0 \
     libnss3 \


### PR DESCRIPTION
Reverts Unity-CI/docker-linux#5

Unfortunately we found out that there are some (not-MVP-worthy) challenges with `--mount=type=tmpfs,target=/tmp` during build time, as it's an experimental feature of BuildKit. 

During runtime it could work but during build time it was not writing to the tmpfs, or not extending the volume to be bigger than a few megs.